### PR TITLE
Update placeholders to new syntax.

### DIFF
--- a/shortcuts.yml
+++ b/shortcuts.yml
@@ -1,17 +1,37 @@
-dbt< 0:
-  url: http://reiseauskunft.bahn.de/bin/query.exe/dl?S=<Start>&Z=balatonstr%21&start=1
+dbt< 2:
+  url: http://reiseauskunft.bahn.de/bin/query.exe/dl?S=<Start>&Z=balatonstr%21&T=<Zeit>&start=1
+  title: DB-Auskunft nach Hause Textversion
+dbt< 3:
+  url: http://reiseauskunft.bahn.de/bin/query.exe/dl?S=<Start>&Z=balatonstr%21&T=<Zeit>&D=<Datum>&start=1
   title: DB-Auskunft nach Hause Textversion
 rb 0:
   url: http://www.niederschlagsradar.de/h.aspx?regio=bln&j=-3&srt=loop1stunde
   title: Niederschlagsradar Berlin
-db< 0:
+dbt< 1:
+  url: http://reiseauskunft.bahn.de/bin/query.exe/dl?S=<Start>&Z=balatonstr%21&start=1
+  title: DB-Auskunft nach Hause Textversion
+db< 2:
+  url: http://reiseauskunft.bahn.de/bin/query.exe/d?S=<Start>&Z=s%20ostb%21&T=<Zeit>&start=1
+  title: DB-Auskunft nach Hause
+db< 3:
+  url: http://reiseauskunft.bahn.de/bin/query.exe/d?S=<Start>&Z=s%20ostb%21&T=<Zeit>&D=<Datum>&start=1
+  title: DB-Auskunft nach Hause
+db< 1:
   url: http://reiseauskunft.bahn.de/bin/query.exe/d?S=<Start>&Z=s%20ostb%21&start=1
   title: DB-Auskunft nach Hause
-db> 0:
+db> 3:
+  url: 'http://reiseauskunft.bahn.de/bin/query.exe/d?S=s%20zeper%21&Z=<Ziel: {type:
+    city}>&T=<Zeit: {type: time, output: HH:mm}>&D=<Datum: {type: date, output: DD.MM.YYYY}>&start=1'
+  title: DB-Auskunft von Zuhause
+db> 2:
+  url: 'http://reiseauskunft.bahn.de/bin/query.exe/d?S=s%20zeper%21&Z=<Ziel: {type:
+    city}>&T=<Zeit: {type: time, output: HH:mm}>&start=1'
+  title: DB-Auskunft von Zuhause
+db> 1:
   url: 'http://reiseauskunft.bahn.de/bin/query.exe/d?S=s%20zeper!&Z=<Ziel: {type:
     city}>&start=1'
   title: DB-Auskunft von Zuhause
-'- 0':
+'- 1':
   url: http://www.google.com/search?hl=<$language>&q=<query>&ie=utf-8&btnI=1
   title: Google Web, go directly to first result
   tags:
@@ -19,7 +39,7 @@ db> 0:
   - google
   examples:
     berlin: Search for "berlin"
-gd> 0:
+gd> 1:
   url: http://maps.google.com/maps?hl=<$language>&saddr=berlin&daddr=<destination>
   title: Google Maps Directions (Routing)
   tags:
@@ -27,7 +47,7 @@ gd> 0:
   - google
   - routing
   - route
-titsa> 0:
+titsa> 1:
   url: https://www.google.com/maps?saddr=puente zurita, Santa Cruz de Tenerife,+Espa%C3%B1a&daddr=<destino>,%20Tenerife,%20Espa%C3%B1a&f=d&dirflg=r
   title: Transportes Interurbanos de Tenerife
   tags:
@@ -38,15 +58,37 @@ titsa> 0:
   - maps
   examples:
     trinidad: Próxima connection a Trinidad
-ff 0:
+ff 1:
+  url: 'http://mobile.bahn.de/bin/mobil/query.exe/dox?S=000733102&Z=<Ziel: {type:
+    city}>&start=1'
+  title: DB-Auskunft von U Friedrichsfelde Textversion
+ff 2:
+  url: 'http://mobile.bahn.de/bin/mobil/query.exe/dox?S=000733102&Z=<Ziel>&T=<Zeit:
+    {type: time}>&start=1'
+  title: DB-Auskunft von U Friedrichsfelde Textversion
+ff 3:
   url: 'http://reiseauskunft.bahn.de/bin/query.exe/dl?S=000733102&Z=<Ziel>&T=<Zeit:
     {type: time}>&D=<Datum: {type: date, output: DD.MM.YY}>&start=1'
   title: DB-Auskunft von U Friedrichsfelde Textversion
-np 0:
+np 1:
+  url: http://reiseauskunft.bahn.de/bin/query.exe/dl?S=s nöldnerplatz%21&Z=<Ziel>&start=1
+  title: DB-Auskunft von S Nöldnerplatz Textversion
+np 2:
+  url: 'http://reiseauskunft.bahn.de/bin/query.exe/dl?S=s nöldnerplatz%21&Z=<Ziel>&T=<Zeit:
+    {type: time}>&start=1'
+  title: DB-Auskunft von S Nöldnerplatz Textversion
+np 3:
   url: 'http://reiseauskunft.bahn.de/bin/query.exe/dl?S=s nöldnerplatz%21&Z=<Ziel>&T=<Zeit:
     {type: time}>&D=<Datum: {type: date, output: DD.MM.YY}>&start=1'
   title: DB-Auskunft von S Nöldnerplatz Textversion
-li 0:
+li 2:
+  url: 'http://reiseauskunft.bahn.de/bin/query.exe/dl?S=s Lichtenberg%21&Z=<Ziel>&T=<Zeit:
+    {type: time}>&start=1'
+  title: DB-Auskunft von Lichtenberg Textversion
+li 1:
+  url: http://reiseauskunft.bahn.de/bin/query.exe/dl?S=s Lichtenberg%21&Z=<Ziel>&start=1
+  title: DB-Auskunft von Lichtenberg Textversion
+li 3:
   url: 'http://reiseauskunft.bahn.de/bin/query.exe/dl?S=s Lichtenberg%21&Z=<Ziel>&T=<Zeit:
     {type: time}>&D=<Datum: {type: date, output: DD.MM.YY}>&start=1'
   title: DB-Auskunft von Lichtenberg Textversion
@@ -60,11 +102,18 @@ wipo 0:
     simpleSearchSearchForm:j_idt411: workaround
     javax.faces.ViewState: 6080588354588600159:-6093555034371762015
   title: WIPO Patent Search
-br 0:
+br 1:
+  url: 'http://mobile.bahn.de/bin/mobil/query.exe/dox?S=8089006&Z=<Ziel: {type: city}>&start=1'
+  title: DB-Auskunft von Betriebsbahnhof Rummelsburg
+br 2:
+  url: 'http://mobile.bahn.de/bin/mobil/query.exe/dox?S=8089006&Z=<Ziel>&T=<Zeit:
+    {type: time}>&start=1'
+  title: DB-Auskunft von Betriebsbahnhof Rummelsburg
+br 3:
   url: 'http://reiseauskunft.bahn.de/bin/query.exe/dl?S=8089006&Z=<Ziel>&T=<Zeit:
     {type: time}>&D=<Datum: {type: date, output: DD.MM.YY}>&start=1'
   title: DB-Auskunft von Betriebsbahnhof Rummelsburg
-db 0:
+db 2:
   url: 'http://reiseauskunft.bahn.de/bin/query.exe/d?S=<Start: {type: city}>&Z=<Ziel:
     {type: city}>&timesel=depart&start=1'
   title: Deutsche Bahn Fahrplanauskunft
@@ -77,3 +126,4 @@ db 0:
     b, hh: Nächste Bahn-Verbindung von Berlin nach Hamburg, Eingabe über Autokennzeichen
     sxf, txl: Nächste Bahn-Verbindung von Flughafen Berlin-Tegel zum Flughafen Berlin-Schönefeld,
       Eingabe über IATA-Flughafencodes
+

--- a/shortcuts.yml
+++ b/shortcuts.yml
@@ -126,4 +126,3 @@ db 2:
     b, hh: Nächste Bahn-Verbindung von Berlin nach Hamburg, Eingabe über Autokennzeichen
     sxf, txl: Nächste Bahn-Verbindung von Flughafen Berlin-Tegel zum Flughafen Berlin-Schönefeld,
       Eingabe über IATA-Flughafencodes
-


### PR DESCRIPTION
Placeholder syntax changed from {%query} to <query>.

Read more: https://trovu.net/docs/shortcuts/url/